### PR TITLE
Update call to pyFAI.azimuthalIntegrator

### DIFF
--- a/trx/azav.py
+++ b/trx/azav.py
@@ -17,7 +17,7 @@ from . import filters
 from .mask import interpretMasks
 import re
 import fabio
-import pyFAI
+import pyFAI, pyFAI.azimuthalIntegrator
 
 
 g_default_extension='.h5'


### PR DESCRIPTION
Needed to avoid the following error:
AttributeError: 'module' object has no attribute 'azimuthalIntegrator'
using pyFAI >= 0.16.0