### PR TITLE
readLogFile encoding

### DIFF
--- a/trx/utils/files.py
+++ b/trx/utils/files.py
@@ -52,8 +52,8 @@ def readLogFile(fname,skip_first=0,last=None,converters=None,
   # as it does not like the space ...
   names = lines[iline-1][1:].split()
 
-  data=np.genfromtxt(fname,skip_header=iline,names=names,dtype=None,
-       converters = converters, excludelist = [] )
+  data=np.genfromtxt(fname, skip_header=iline, names=names, dtype=None,
+                     encoding=None, converters=converters, excludelist=[])
 
   # skip firsts/lasts
   data = data[skip_first:last]


### PR DESCRIPTION
This is to avoid the annoying: VisibleDeprecationWarning
(Reading unicode strings without specifying the encoding argument is deprecated. Set the encoding, use None for the system default.)